### PR TITLE
[BSP-2024] try to revert to master, upgrade to 2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 # Changelog
 
+## 13/10/2018 - Version 2.5.0
+
+Release changes:
+
+* Bump dependencies
+* Cross build
+
+## 17/04/2018 - Version 2.4.0
+
+Release changes:
+
+* #3 Fix Implications of the streaming nature of Request/Response Entities. Thanks to @NicolasRouquette!
+
 ## 02/04/2018 - Version 2.3.0
 
 Release changes:
 
-* Bump dependancies
+* Bump dependencies
 * #1 Add support for Http connection headers. Thanks to @NicolasRouquette!
 
 ## 22/01/2018 - Version 2.2.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following dependency:
 ```scala
   resolvers += Resolver.bintrayRepo("jarlakxen", "maven")
 
-  "com.github.jarlakxen" %% "drunk" % "2.2.0"
+  "com.github.jarlakxen" %% "drunk" % "2.5.0"
 ```
 
 Then, import:
@@ -20,10 +20,45 @@ Then, import:
   import com.github.jarlakxen.drunk._
   import io.circe._, io.circe.generic.semiauto._
   import sangria.macros._
+```
 
-  
+There are three ways to create a `GraphQLClient`:
+
+1) As Akka Https flow connection
+
+```
+ import akka.http.scaladsl.model.Uri
+ 
+ val uri: Uri = Uri(s"https://$host:$port/api/graphql")
+
+ val http: HttpExt = Http()
+ val flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = http.outgoingConnectionHttps(uri.authority.host.address(), uri.effectivePort)
+ val client = GraphQLClient(uri, flow, clientOptions = ClientOptions.Default, headers = Nil)
+
+```
+
+2) As Akka Http flow connection
+
+```
+ import akka.http.scaladsl.model.Uri
+ 
+ val uri: Uri = Uri(s"http://$host:$port/api/graphql")
+
+ val http: HttpExt = Http()
+ val flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = http.outgoingConnection(uri.authority.host.address(), uri.effectivePort)
+ val client = GraphQLClient(uri, flow, clientOptions = ClientOptions.Default, headers = Nil)
+
+```
+
+3) As Akka Http single request
+
+```  
   val client = GraphQLClient(s"http://$host:$port/api/graphql")
+```
 
+Then, query:
+
+```
   val query =
     graphql"""
       query HeroAndFriends {

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ name := projectName
 
 organization := "com.github.jarlakxen"
 
-crossScalaVersions := Seq("2.12.7", "2.11.12")
+crossScalaVersions := Seq("2.13.1", "2.12.9")
 
 scalaVersion := crossScalaVersions.value.head
 
@@ -41,14 +41,14 @@ scalacOptions ++= Seq(
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots"))
 
 // ··· Project Dependencies ···
-val sangriaV        = "1.4.+"
-val sangriaCirceV   = "1.2.1"
-val akkaHttpV       = "10.1.+"
-val akkaHttpCircleV = "1.22.+"
-val circeV          = "0.10.+"
+val sangriaV        = "2.0.0-M1"
+val sangriaCirceV   = "1.3.0"
+val akkaHttpV       = "10.1.10"
+val akkaHttpCircleV = "1.28.+"
+val circeV          = "0.12.1"
 val slf4JV          = "1.7.25"
 val logbackV        = "1.2.3"
-val scalatestV      = "3.0.5"
+val scalatestV      = "3.0.8"
 
 libraryDependencies ++= Seq(
   // --- GraphQL --
@@ -64,6 +64,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"           %  "slf4j-api"        % slf4JV,
   "ch.qos.logback"      %  "logback-classic"  % logbackV        % Test,
   // --- Testing ---
+  "com.typesafe.akka"   %% "akka-testkit"       % "2.5.25"      % Test,
   "com.typesafe.akka"   %% "akka-http-testkit"  % akkaHttpV     % Test,
   "org.scalatest"       %% "scalatest"          % scalatestV    % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -10,13 +10,15 @@ name := projectName
 
 organization := "com.github.jarlakxen"
 
-crossScalaVersions := Seq("2.12.5")
+crossScalaVersions := Seq("2.12.7", "2.11.12")
 
 scalaVersion := crossScalaVersions.value.head
 
 organizationName := "Facundo Viale"
 startYear := Some(2018)
 licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+
+publishMavenStyle := true
 
 // ··· Project Options ···
 
@@ -39,11 +41,11 @@ scalacOptions ++= Seq(
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots"))
 
 // ··· Project Dependencies ···
-val sangriaV        = "1.4.0"
+val sangriaV        = "1.4.+"
 val sangriaCirceV   = "1.2.1"
-val akkaHttpV       = "10.1.1"
-val akkaHttpCircleV = "1.20.0"
-val circeV          = "0.9.3"
+val akkaHttpV       = "10.1.+"
+val akkaHttpCircleV = "1.22.+"
+val circeV          = "0.10.+"
 val slf4JV          = "1.7.25"
 val logbackV        = "1.2.3"
 val scalatestV      = "3.0.5"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.2.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.3.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("org.foundweekends"  % "sbt-bintray"  % "0.5.4")
 // addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"  % "0.5.7")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.0.0")
+
+addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.7")
+addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.9")
 
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("org.foundweekends"  % "sbt-bintray"  % "0.5.2")
+addSbtPlugin("org.foundweekends"  % "sbt-bintray"  % "0.5.4")
 
 // addSbtPlugin("com.lucidchart"    % "sbt-scalafmt"  % "1.15")
 
 // addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"  % "0.5.7")
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "3.0.2")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.0.0")

--- a/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
@@ -27,7 +27,7 @@ import backend.{AkkaBackend, AkkaConnectionBackend, AkkaHttpBackend}
 import extensions.{GraphQLExtensions, NoExtensions}
 import io.circe._
 import io.circe.parser._
-import sangria._
+import sangria.{ ast => _, _ }
 import sangria.ast.Document
 import sangria.introspection._
 import sangria.marshalling.circe._

--- a/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/GraphQLClient.scala
@@ -16,21 +16,22 @@
 
 package com.github.jarlakxen.drunk
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util._
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import backend.{AkkaHttpBackend, GraphQLBackend}
-import extensions.{GraphQLExtensions, NoExtensions}
-import io.circe._
-import io.circe.parser._
+
+import backend.AkkaHttpBackend
+import extensions.{ GraphQLExtensions, NoExtensions }
+import io.circe._, io.circe.parser._
 import sangria._
 import sangria.ast.Document
 import sangria.introspection._
 import sangria.marshalling.circe._
 import sangria.parser.{ SyntaxError, QueryParser }
 
-class GraphQLClient private[GraphQLClient] (uri: Uri, options: ClientOptions, backend: GraphQLBackend) {
+class GraphQLClient private[GraphQLClient] (uri: Uri, options: ClientOptions, backend: AkkaHttpBackend) {
   import GraphQLClient._
 
   private[drunk] def execute[Res, Vars](doc: Document, variables: Option[Vars], name: Option[String])(
@@ -139,7 +140,7 @@ object GraphQLClient {
 
   type GraphQLResponse[Res] = Either[GraphQLResponseError, GraphQLResponseData[Res]]
 
-  def apply(uri: String, backend: GraphQLBackend, clientOptions: ClientOptions): GraphQLClient =
+  def apply(uri: String, backend: AkkaHttpBackend, clientOptions: ClientOptions): GraphQLClient =
     new GraphQLClient(Uri(uri), clientOptions, backend)
 
   def apply(uri: String, options: ConnectionOptions = ConnectionOptions.Default, clientOptions: ClientOptions = ClientOptions.Default): GraphQLClient =

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaBackend.scala
@@ -1,0 +1,44 @@
+package com.github.jarlakxen.drunk.backend
+
+import java.io.UnsupportedEncodingException
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.coding.{Deflate, Gzip, NoCoding}
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.headers.HttpEncodings
+import akka.stream.ActorMaterializer
+import akka.util.ByteString
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AkkaBackend {
+  implicit val as: ActorSystem
+  implicit val mat: ActorMaterializer
+
+  def send(body: String): Future[(Int, String)]
+
+  protected def encodingFromContentType(ct: String): Option[String] =
+    ct.split(";").map(_.trim.toLowerCase).collectFirst {
+      case s if s.startsWith("charset=") => s.substring(8)
+    }
+
+  protected def decodeResponse(response: HttpResponse): HttpResponse = {
+    val decoder = response.encoding match {
+      case HttpEncodings.gzip     => Gzip
+      case HttpEncodings.deflate  => Deflate
+      case HttpEncodings.identity => NoCoding
+      case ce =>
+        throw new UnsupportedEncodingException(s"Unsupported encoding: $ce")
+    }
+
+    decoder.decodeMessage(response)
+  }
+
+  protected def bodyToString(hr: HttpResponse, charsetFromHeaders: String): Future[String] = {
+    implicit val ec: ExecutionContext = as.dispatcher
+
+    hr.entity.dataBytes
+      .runFold(ByteString.empty)(_ ++ _)
+      .map(_.decodeString(charsetFromHeaders))
+  }
+}

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaConnectionBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaConnectionBackend.scala
@@ -1,0 +1,62 @@
+package com.github.jarlakxen.drunk.backend
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http.OutgoingConnection
+import akka.http.scaladsl.model._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Flow, Sink, Source}
+
+import scala.collection.immutable
+import scala.concurrent.{ExecutionContext, Future}
+
+class AkkaConnectionBackend  private[AkkaConnectionBackend] (
+  uri: Uri,
+  flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]],
+  headers: immutable.Seq[HttpHeader]
+)(override implicit val as: ActorSystem, override implicit val mat: ActorMaterializer)
+   extends AkkaBackend {
+
+  def send(body: String): Future[(Int, String)] = {
+    implicit val ec: ExecutionContext = as.dispatcher
+
+    val req = HttpRequest(
+      method = HttpMethods.POST,
+      uri = uri,
+      headers = headers,
+      entity = HttpEntity(ContentTypes.`application/json`, body)
+    )
+
+    val res = Source.single(req).via(flow).runWith(Sink.head)
+
+    res.flatMap { hr =>
+      val code = hr.status.intValue()
+
+      val charsetFromHeaders = encodingFromContentType(hr.entity.contentType.toString).getOrElse("utf-8")
+      val decodedResponse = decodeResponse(hr)
+      val stringBody = bodyToString(decodedResponse, charsetFromHeaders)
+
+      if (code >= 200 && code < 300) {
+        stringBody.map { body =>
+          hr.discardEntityBytes()
+          (code, body)
+        }
+      } else {
+        stringBody.flatMap { body =>
+          hr.discardEntityBytes()
+          Future.failed(new RuntimeException(s"${uri.toString} return $code with body: $body"))
+        }
+      }
+    }
+  }
+
+}
+
+object AkkaConnectionBackend {
+
+  def apply(uri: Uri,
+             flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]],
+             headers: immutable.Seq[HttpHeader] = Nil
+           )( implicit  as: ActorSystem,  mat: ActorMaterializer): AkkaConnectionBackend =
+    new AkkaConnectionBackend(uri, flow, headers)
+
+}

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaHttpBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaHttpBackend.scala
@@ -36,6 +36,9 @@ import com.github.jarlakxen.drunk._
 
 import scala.concurrent.{ExecutionContext, Future}
 
+trait GraphQLBackend {
+  def send(uri: Uri, body: String, options: ClientOptions): Future[(Int, String)]
+}
 
 class AkkaHttpBackend private[AkkaHttpBackend] (
   actorSystem: ActorSystem,
@@ -44,7 +47,7 @@ class AkkaHttpBackend private[AkkaHttpBackend] (
   customHttpsContext: Option[HttpsConnectionContext],
   customConnectionPoolSettings: Option[ConnectionPoolSettings],
   customLog: Option[LoggingAdapter],
-  headers: immutable.Seq[HttpHeader]) extends GraphQLBackend {
+  headers: immutable.Seq[HttpHeader]) {
 
   private implicit val as: ActorSystem = actorSystem
   private implicit val materializer: ActorMaterializer = ActorMaterializer()

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaHttpBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/AkkaHttpBackend.scala
@@ -31,14 +31,10 @@ import akka.http.scaladsl.model.headers.HttpEncodings
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
+
 import com.github.jarlakxen.drunk._
-
-import scala.concurrent.{ExecutionContext, Future}
-
-trait GraphQLBackend {
-  def send(uri: Uri, body: String, options: ClientOptions): Future[(Int, String)]
-}
 
 class AkkaHttpBackend private[AkkaHttpBackend] (
   actorSystem: ActorSystem,
@@ -88,7 +84,7 @@ class AkkaHttpBackend private[AkkaHttpBackend] (
       if (code >= 200 && code < 300) {
         stringBody.map((code, _))
       } else {
-        stringBody.flatMap { body => Future.failed(new RuntimeException(s"${uri.toString} returned $code with body: $body")) }
+        stringBody.flatMap { body => Future.failed(new RuntimeException(s"${uri.toString} return $code with body: $body")) }
       }
     }
   }

--- a/src/main/scala/com/github/jarlakxen/drunk/backend/GraphQLBackend.scala
+++ b/src/main/scala/com/github/jarlakxen/drunk/backend/GraphQLBackend.scala
@@ -1,8 +1,0 @@
-package com.github.jarlakxen.drunk.backend
-
-import akka.http.scaladsl.model.Uri
-import scala.concurrent.Future
-
-trait GraphQLBackend {
-  def send(uri: Uri, body: String): Future[(Int, String)]
-}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.5.0"
+version in ThisBuild := "2.6.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.3.0"
+version in ThisBuild := "2.5.0"


### PR DESCRIPTION
# Backstory

We want to upgrade dendron to scala 2.13 - most of our dependencies have published a version for it, but drunk is _very dead_ and hasn't. (it can't even be installed from the original repo any more!)

Also, we have (for some reason) a very tiny fork of Drunk created by Piotr. It's _really_ similar to master, but incompatible because of different trait setup.

(also, fun fact, when you create a PR on a fork, the default option is to create a PR to the _source_ repository. so there's now a copy of this PR on that dead repo. :facepalm: )

## Approaches

Since drunk is dead, our choices were:

1) build it for 2.13 in our custom fork, continue using it;
2) replace it with a tiny http client
3) try using another scala client library

This is option 1, as it's a relatively small change.

We considered 2 + 3 because we don't use graphql extensively in dendron; I don't think we use any advanced cursor progression features or anything, and are basically just hand-writing queries as strings and blasting them over the network.

Option 2 is somewhat impractical, as we'd be basically writing our own graphql client, and would need to add tests etc for all of the parsing. It's time consuming, and since we don't use any advanced graphql features, it feels like not an area of focus for us?

Option 3 is also impractical; the main alternative is [caliban](https://ghostdogpr.github.io/caliban/docs/client.html), but that requires building a typed schema, and rewriting your queries using case classes instead of strings. It's maybe not a bad idea, but a lot of work for something that we would be using a tiny fraction of the features of. (I found [one another client](https://index.scala-lang.org/gemini-hlsw/clue/clue-scalajs/0.16.0?target=_sjs1.x_2.13), but it's got basically no traction on github, so may just be the same risk as using drunk!)

Option 1 seemed like the best of a bad bunch, since it _works_ as is. Maybe one day we'll reconsider?

# This PR

This PR:
* reverts Piotr's changes; they don't seem very important, and the main repo did something very similar itself afterwards
* merges in the master branches' changes
* merges in the commit from this PR: https://github.com/Jarlakxen/drunk/pull/11/commits/341002e5b67e2283e735b9e6247c159a405e80f8 (which will never be merged, as the repo's very dead)

# Testing

I've been testing it by:
* running `sbt +publishLocal` - which publishes a version for both 2.12 and 2,13 to your local cache
* change your build.sbt line to `"com.github.jarlakxen" %% "drunk" % "2.6.0",`
    * it needs to use the scala package name for local dependencies, not the `tray.io` one we were using before
* remove old drunk stuff; this requires very minimal changes, as seen in the 1 commit here: https://github.com/trayio/dendron/commits/dan-belsey/BSP-2024/upgrade-drunk-to-213-or-replace-it 
    * build failing as this package isn't published anywhere - but passes tests locally!